### PR TITLE
Expose set_context function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openai-safe"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",
     "Dario Lencina <dario@neferdata.com>",
 ]
-keywords = ["openai", "api", "wrapper", "rust", "typesafe"]
+keywords = ["openai", "api", "assistant", "rust", "typesafe"]
 description = "OpenAI Framework for Rust"
 license = "MIT"
 repository = "https://github.com/neferdata/openai-typesafe-rs"

--- a/examples/use_openai_assistant.rs
+++ b/examples/use_openai_assistant.rs
@@ -29,8 +29,21 @@ async fn main() -> Result<()> {
 
     let openai_file = OpenAIFile::new(bytes, &api_key, true).await?;
 
-    // Extract invoice detail using Assistant API
-    let invoice = OpenAIAssistant::new(OpenAIModels::Gpt4Turbo, &api_key, true)
+    let exciting_bands = vec![
+        "Metallica",
+        "Guns N' Roses",
+        "Slayer",
+        "Iron Maiden",
+        "Black Sabbath",
+    ];
+
+    // Extract concert information using Assistant API
+    let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4Turbo, &api_key, true)
+        .await?
+        .set_context(
+            "Only include bands from the provided list",
+            &exciting_bands
+        )
         .await?
         .get_answer::<ConcertInfo>(
             "Extract the information requested in the response type from the attached concert information.",
@@ -38,6 +51,6 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    println!("Concert Info: {:?}", invoice);
+    println!("Concert Info: {:?}", concert_info);
     Ok(())
 }

--- a/examples/use_openai_assistant.rs
+++ b/examples/use_openai_assistant.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     let openai_file = OpenAIFile::new(bytes, &api_key, true).await?;
 
     let exciting_bands = vec![
-        "Metallica",
+        "Metallica Inc.",
         "Guns N' Roses",
         "Slayer",
         "Iron Maiden",
@@ -41,12 +41,14 @@ async fn main() -> Result<()> {
     let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4Turbo, &api_key, true)
         .await?
         .set_context(
-            "Only include bands from the provided list",
+            "exciting_bands",
             &exciting_bands
         )
         .await?
         .get_answer::<ConcertInfo>(
-            "Extract the information requested in the response type from the attached concert information.",
+            "Extract the information requested in the response type from the attached concert information.
+            Before returning a response try to match the band name you discovered to the names provided in the 'exciting_bands' list.
+            Change the name of the band to the one in 'exciting_bands' if the names are similar.",
             &[openai_file.id],
         )
         .await?;

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -185,6 +185,23 @@ impl OpenAIAssistant {
     }
 
     /*
+     * This method can be used to provide data that will be used as context for the prompt.
+     * Using this function you can provide multiple sets of context data by calling it multiple times. New values will be as messages to the thread
+     * It accepts any struct that implements the Serialize trait.
+     */
+    pub async fn set_context<T: Serialize>(mut self, description: &str, data: &T) -> Result<Self> {
+        let serialized_data = if let Ok(json) = serde_json::to_string(&data) {
+            json
+        } else {
+            return Err(anyhow!("Unable serialize provided input data."));
+        };
+        let message = format!("{description}: {serialized_data}");
+        let file_ids = Vec::new();
+        self.add_message(&message, &file_ids).await?;
+        Ok(self)
+    }
+
+    /*
      * This function creates a Thread and updates the thread_id of the OpenAIAssistant struct
      */
     async fn add_message(&mut self, message: &str, file_ids: &[String]) -> Result<()> {

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -184,18 +184,18 @@ impl OpenAIAssistant {
             .ok_or(anyhow!("No valid response form OpenAI Assistant found."))
     }
 
-    /*
-     * This method can be used to provide data that will be used as context for the prompt.
-     * Using this function you can provide multiple sets of context data by calling it multiple times. New values will be as messages to the thread
-     * It accepts any struct that implements the Serialize trait.
-     */
-    pub async fn set_context<T: Serialize>(mut self, description: &str, data: &T) -> Result<Self> {
+    ///
+    /// This method can be used to provide data that will be used as context for the prompt.
+    /// Using this function you can provide multiple sets of context data by calling it multiple times. New values will be as messages to the thread
+    /// It accepts any struct that implements the Serialize trait.
+    ///
+    pub async fn set_context<T: Serialize>(mut self, dataset_name: &str, data: &T) -> Result<Self> {
         let serialized_data = if let Ok(json) = serde_json::to_string(&data) {
             json
         } else {
             return Err(anyhow!("Unable serialize provided input data."));
         };
-        let message = format!("{description}: {serialized_data}");
+        let message = format!("'{dataset_name}'= {serialized_data}");
         let file_ids = Vec::new();
         self.add_message(&message, &file_ids).await?;
         Ok(self)


### PR DESCRIPTION
The public new function allows users to provide additional context for the OpenAI Assistant. For example, we will use it to provide email header when passing the invoice file.

Under the hoods the new function uses the existing add_message function without any changes to it, so there is backward compatibility issues.

I also modified the assistant example to use the new function.