### PR TITLE
[OpenAIAssistant] Initialize thread in constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-safe"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",

--- a/examples/use_openai_assistant.rs
+++ b/examples/use_openai_assistant.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 pub struct ConcertInfo {
     dates: Vec<String>,
     band: String,
+    genre: String,
     venue: String,
     city: String,
     country: String,
@@ -29,26 +30,26 @@ async fn main() -> Result<()> {
 
     let openai_file = OpenAIFile::new(bytes, &api_key, true).await?;
 
-    let exciting_bands = vec![
-        "Metallica Inc.",
-        "Guns N' Roses",
-        "Slayer",
-        "Iron Maiden",
-        "Black Sabbath",
+    let bands_genres = vec![
+        ("Metallica", "Metal"),
+        ("The Beatles", "Rock"),
+        ("Daft Punk", "Electronic"),
+        ("Miles Davis", "Jazz"),
+        ("Johnny Cash", "Country"),
     ];
 
     // Extract concert information using Assistant API
     let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4Turbo, &api_key, true)
         .await?
         .set_context(
-            "exciting_bands",
-            &exciting_bands
+            "bands_genres",
+            &bands_genres
         )
         .await?
         .get_answer::<ConcertInfo>(
             "Extract the information requested in the response type from the attached concert information.
-            Before returning a response try to match the band name you discovered to the names provided in the 'exciting_bands' list.
-            Change the name of the band to the one in 'exciting_bands' if the names are similar.",
+            The response should include the genre of the music the 'band' represents.
+            The mapping of bands to genres was provided in 'bands_genres' list in a previous message.",
             &[openai_file.id],
         )
         .await?;

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -47,8 +47,14 @@ impl OpenAIAssistant {
             debug,
             api_key: open_ai_key.to_string(),
         };
+
         //Call OpenAI API to get an ID for the assistant
         new_assistant.create_assistant().await?;
+
+        //Add first message thus initializing the thread
+        new_assistant
+            .add_message(OPENAI_ASSISTANT_INSTRUCTIONS, &Vec::new())
+            .await?;
 
         Ok(new_assistant)
     }

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -53,7 +53,7 @@ impl OpenAIAssistant {
 
         //Add first message thus initializing the thread
         new_assistant
-            .add_message("OPENAI_ASSISTANT_INSTRUCTIONS", &Vec::new())
+            .add_message(OPENAI_ASSISTANT_INSTRUCTIONS, &Vec::new())
             .await?;
 
         Ok(new_assistant)

--- a/src/assistant.rs
+++ b/src/assistant.rs
@@ -26,7 +26,7 @@ use tokio::time::timeout;
 /// your own tools on our platform.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct OpenAIAssistant {
-    id: String,
+    id: Option<String>,
     thread_id: Option<String>,
     run_id: Option<String>,
     model: OpenAIModels,
@@ -39,7 +39,7 @@ impl OpenAIAssistant {
     //Constructor
     pub async fn new(model: OpenAIModels, open_ai_key: &str, debug: bool) -> Result<Self> {
         let mut new_assistant = OpenAIAssistant {
-            id: "this_will_change".to_string(),
+            id: None,
             thread_id: None,
             run_id: None,
             model,
@@ -53,7 +53,7 @@ impl OpenAIAssistant {
 
         //Add first message thus initializing the thread
         new_assistant
-            .add_message(OPENAI_ASSISTANT_INSTRUCTIONS, &Vec::new())
+            .add_message("OPENAI_ASSISTANT_INSTRUCTIONS", &Vec::new())
             .await?;
 
         Ok(new_assistant)
@@ -108,7 +108,7 @@ impl OpenAIAssistant {
             })?;
 
         //Add correct ID to self
-        self.id = response_deser.id;
+        self.id = Some(response_deser.id);
 
         Ok(())
     }
@@ -380,17 +380,22 @@ impl OpenAIAssistant {
      * This function starts an assistant run
      */
     async fn start_run(&mut self) -> Result<()> {
-        if self.thread_id.is_none() {
-            return Err(anyhow!("No active thread detected."));
-        }
+        let assistant_id = if let Some(id) = self.id.clone() {
+            id
+        } else {
+            return Err(anyhow!("No active assistant detected."));
+        };
 
-        let run_url = format!(
-            "https://api.openai.com/v1/threads/{}/runs",
-            self.thread_id.clone().unwrap_or_default()
-        );
+        let thread_id = if let Some(id) = self.thread_id.clone() {
+            id
+        } else {
+            return Err(anyhow!("No active thread detected."));
+        };
+
+        let run_url = format!("https://api.openai.com/v1/threads/{}/runs", thread_id);
 
         let body = json!({
-            "assistant_id": self.id.clone(),
+            "assistant_id": assistant_id,
         });
 
         //Make the API call
@@ -435,19 +440,19 @@ impl OpenAIAssistant {
      * This function checks the status of an assistant run
      */
     async fn get_run_status(&self) -> Result<OpenAIRunResp> {
-        if self.thread_id.is_none() {
+        let thread_id = if let Some(id) = self.thread_id.clone() {
+            id
+        } else {
             return Err(anyhow!("No active thread detected."));
-        }
+        };
 
-        if self.run_id.is_none() {
+        let run_id = if let Some(id) = self.run_id.clone() {
+            id
+        } else {
             return Err(anyhow!("No active run detected."));
-        }
+        };
 
-        let run_url = format!(
-            "https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}",
-            thread_id = self.thread_id.clone().unwrap_or_default(),
-            run_id = self.run_id.clone().unwrap_or_default(),
-        );
+        let run_url = format!("https://api.openai.com/v1/threads/{thread_id}/runs/{run_id}");
 
         //Make the API call
         let client = Client::new();


### PR DESCRIPTION
The PR includes the following changes:
- [ ] A thread is now initialized within the constructor of `OpenAIAssistant`. Previously it was only done when the first message was added. Because of that if you initialized an instance it would not yet have a thread created so making a copy of it and adding new messages would result in different threads for each copy. Now all copies will be on the same thread, which  makes passing the thread via session or state easier.
- [ ] Other improvements to constructor to be more idiomatic, ie. using Option<> instead of random string at initialization.
- [ ] Update to the example which is now both working more stably and better shows how set_context can be used to provide additional data to the model.
- [ ] Bump of version number.